### PR TITLE
Change Element type to ReactNode

### DIFF
--- a/src/react-transition-collapse.tsx
+++ b/src/react-transition-collapse.tsx
@@ -24,7 +24,7 @@ type DomEl = null | HTMLElement
 
 type transitionProps = {
   expanded: boolean
-  children: Element
+  children: React.ReactNode
   duration?: number | string
   animationType?: 'scale' | 'translate'
 }


### PR DESCRIPTION
Fixing #1 
The `transitionProps` type expects `children` to be an `Element` which does not allow simple texts and `div` for example.

I've changed the type of children to `React.ReactNode` which is more suitable